### PR TITLE
display: inline removed from badge.css

### DIFF
--- a/src/assets/css/badge.css
+++ b/src/assets/css/badge.css
@@ -2,10 +2,6 @@
 	color: inherit;
 }
 
-.badge {
-	display: inline;
-}
-
 .badge.inline-block {
 	display: inline-block;
 }


### PR DESCRIPTION
Когда много доступов, то таблица расширяется сильно:
![Screenshot from 2021-05-12 17-49-00](https://user-images.githubusercontent.com/14938095/117996232-a610c200-b34a-11eb-8ac6-f30b7171820b.png)
После поправки:
![Screenshot from 2021-05-12 17-46-57](https://user-images.githubusercontent.com/14938095/117995941-66e27100-b34a-11eb-9989-1bca93f16cfa.png)
